### PR TITLE
Remove process.cwd() as root prefix

### DIFF
--- a/src/serve-static.ts
+++ b/src/serve-static.ts
@@ -233,7 +233,6 @@ export default function serveStatic(
 ): (ctx: Context) => Promise<Context>;
 
 export default function serveStatic(root: string, options: ServeStaticOptions = {}) {
-	root = `${process.cwd()}/${root}`;
 	const {
 		index = "index.html",
 		dirTrailingSlash = true,


### PR DESCRIPTION
use absolute path instead.
```ts
import path from "path";
import Bao from "baojs";
import serveStatic from "serve-static-bun";

const app = new Bao();
const staticFolder = path.join(
  import.meta.dir, // Absolute path to the current file directory -> /home/lazuee/projects/bun/project/server/src
  "..",            // Go up one directory -> /home/lazuee/projects/bun/project/server
  "/public"        // Go into the public folder -> /home/lazuee/projects/bun/project/server/public
);                 // result: /home/lazuee/projects/bun/project/server/public

app.get("/assets/*any", serveStatic(staticFolder, { middlewareMode: "bao", stripFromPathname: "/assets" }));
```